### PR TITLE
Fix #3 and #4 incomplete and packed refs

### DIFF
--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"code.gitea.io/git"
 	"github.com/blang/semver"
 	"github.com/gogits/git"
 	"github.com/pkg/errors"
@@ -128,7 +129,7 @@ func init() {
 func tag(repo *git.Repository, major, minor, patch uint64) error {
 
 	fmt.Printf("Creating v%d.%d.%d\n", major, minor, patch)
-	id, err := repo.GetCommitIdOfBranch("master")
+	id, err := repo.GetBranchCommitID("master")
 	if err != nil {
 		return errors.Wrap(err, "Unable to get commit ID of branch ")
 	}


### PR DESCRIPTION
The original git library dependency (github.com/gogits/git) did not correctly handle refs that have been packed.
Pull request was made to address but appears that repo is no longer in active development.

This PR proposes switching to use the code.gitea.io/git lib (from which the original dependency was forked) as this correctly identifies the tags.