### PR TITLE
Fix issue with incorrect tag generation

### DIFF
--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -61,10 +61,15 @@ var tagCmd = &cobra.Command{
 				fmt.Println("error: ", err)
 				continue
 			}
+			fmt.Printf("v%d.%d.%d\n", sv.Major, sv.Minor, sv.Patch)
 			if sv.Major > maxMajor {
 				maxMajor = sv.Major
 				maxMinor = 0
 				maxPatch = 0
+			}
+
+			if sv.Major < maxMajor {
+				continue
 			}
 
 			if sv.Minor > maxMinor {
@@ -72,10 +77,13 @@ var tagCmd = &cobra.Command{
 				maxPatch = 0
 			}
 
+			if sv.Minor < maxMinor {
+				continue
+			}
+
 			if sv.Patch > maxPatch {
 				maxPatch = sv.Patch
 			}
-			fmt.Printf("v%d.%d.%d\n", sv.Major, sv.Minor, sv.Patch)
 		}
 		var tagged bool
 		if Major {


### PR DESCRIPTION
When existing tags were not sorted, next tag was generated incorrectly. The program would assume minor version from a smaller major version in some cases. For example, if current largest known version was `1.0.0` and `0.0.1` was seen next, the program would increment patch version and produce the next tag as `1.0.2` instead of `1.0.1`. This is fixed by only incrementing minor and patch versions if all. other version numbers match.

See #13 .